### PR TITLE
Issue 1: Make Path Replacement Relative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [2.0.0] - 2023-06-30
+
+- Switch from absolute path matching to relative path matching. If you need custom matching behavior in a given project, this is a stock VSCode feature. See [README -> Features](./README.md#features)
+
 ## [1.1.0] - 2023-06-28
 
 - Fix absolute path replacement.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [2.0.1] - 2023-06-30
+
+- Improve readme.
+
 ## [2.0.0] - 2023-06-30
 
 - Switch from absolute path matching to relative path matching. If you need custom matching behavior in a given project, this is a stock VSCode feature. See [README -> Features](./README.md#features)

--- a/README.md
+++ b/README.md
@@ -59,3 +59,14 @@ I'll probably fix this a some point so path patterns default to mutating the pat
 ## Release Notes
 
 See [CHANGELOG](./CHANGELOG.md)
+
+## Development
+
+Generally you would run the project via F5 in VSCode.
+
+Alternatively, see package.json -> scripts other commands.
+- npm run test
+
+TODO: add information on how to publish.
+
+FUTURE: investigate continuous integration and headless testing https://code.visualstudio.com/api/working-with-extensions/continuous-integration#azure-pipelines

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ Generally you would run the project via F5 in VSCode.
 Alternatively, see package.json -> scripts other commands.
 - npm run test
 
+### File Access in Tests
+
+The test config opens the app with `out/test/example-workspace/` as the default workspace.
+File manipulation tests can be performed in this folder.
+
 TODO: add information on how to publish.
 
 FUTURE: investigate continuous integration and headless testing https://code.visualstudio.com/api/working-with-extensions/continuous-integration#azure-pipelines

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Alternatively, see package.json -> scripts other commands.
 
 ### File Access in Tests
 
-The test config opens the app with `out/test/example-workspace/` as the default workspace.
-File manipulation tests can be performed in this folder.
+The test config opens the app with `./tmp/example-workspace/` as the default workspace.
+File manipulation tests can be performed in this folder. The directory is copied from the project `./src/test/example-workspace` directory as part of the `npm run test` command.
 
 TODO: add information on how to publish.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ path mappers if you have multiple conventions for where you create tests.
 Full path mutation support via JS regex replace.
 Given an absolute path, a path pattern and a test file pattern, you get `absolutePath.replace(pathPattern, testFilePattern)`; anything you can write via https://regex101.com/ will work.
 
+If you want workspace specific behavior, this is built in to VSCode itself. You can activate this feature by editing appropriate settings in the project relative `./.vscode/settings.json` file.
+
 ## Extension Settings
 
 ```javascript -- instead of json to support comments

--- a/README.md
+++ b/README.md
@@ -4,12 +4,9 @@
 
 Published to https://marketplace.visualstudio.com/items?itemName=klondikemarlen.create-test-file
 
-This is an extension that adds a command for create a test file with a name and path inferred from a currently
-open file (or one selected file from the sidebar).
+This is an extension that adds a command for creating a test file, with a given name and path inferred from a currently open file (or one selected file from the sidebar).
 
-For example, if your application code lives under the `app` directory in your workspace and your test code lives under
-the `spec` folder, you can define rules such that for any file `app/foo/bar/filename.rb`, you will create or open a file
-with `spec/foo/bar/filename_spec.rb`. These settings can be customized for each filetype, and you may create multiple
+For example, if your application code lives under the `app` directory in your workspace and your test code lives under the `spec` folder, you can define rules such that for any file `app/foo/bar/filename.rb`, you will create or open a file with `spec/foo/bar/filename_spec.rb`. These settings can be customized for each filetype, and you may create multiple
 path mappers if you have multiple conventions for where you create tests.
 
 ## Features
@@ -44,7 +41,7 @@ For pattern replacement conventions see [Specifying a string as the replacement]
 
 ## Known Issues
 
-Filename replacement does not support full regex replacement.
+While path replacement has full regex support, filename replacement **does not** support full regex replacement.
 
 ## Release Notes
 

--- a/README.md
+++ b/README.md
@@ -44,20 +44,7 @@ For pattern replacement conventions see [Specifying a string as the replacement]
 
 ## Known Issues
 
-The path replacement requires that you supply a matcher against the absolute path if you want to match all paths.
-
-Path patterns that want to inject a pattern for all files, need to use the full absolute path.
-e.g.
-```json
-{
-    "pathPattern": "(/home/user-name/vscode-create-test-file)/?(.*)",
-     "testFilePathPattern": "$1/spec/$2"
-}
-```
-
-Would convert `/home/user-name/vscode-create-test-file/data/examples/example.rb` to `/home/user-name/vscode-create-test-file/spec/data/examples/example_spec.rb'`
-
-I'll probably fix this a some point so path patterns default to mutating the path relative to the project root.
+Filename replacement does not support full regex replacement.
 
 ## Release Notes
 
@@ -72,9 +59,17 @@ Alternatively, see package.json -> scripts other commands.
 
 ### File Access in Tests
 
-The test config opens the app with `./tmp/example-workspace/` as the default workspace.
+The test config opens the app with `./out/tmp/example-workspace/` as the default workspace.
 File manipulation tests can be performed in this folder. The directory is copied from the project `./src/test/example-workspace` directory as part of the `npm run test` command.
 
-TODO: add information on how to publish.
-
 FUTURE: investigate continuous integration and headless testing https://code.visualstudio.com/api/working-with-extensions/continuous-integration#azure-pipelines
+
+### Publishing
+
+See https://code.visualstudio.com/api/working-with-extensions/publishing-extension for full details. The following is a quick refresher:
+
+1. (as needed) `npm install -g @vscode/vsce`
+2. `vsce package`
+3. `vsce publish`
+
+> You might need to periodically refresh your azure dev ops api key.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ If you want workspace specific behavior, this is built in to VSCode itself. You 
 
 ## Extension Settings
 
+For pattern replacement conventions see [Specifying a string as the replacement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement)
+
 ```javascript -- instead of json to support comments
 // Basic settings
 "createTestFile.nameTemplate": "{filename}_spec", // If file is named foo.bar, will create test named foo_spec.bar
@@ -29,10 +31,11 @@ If you want workspace specific behavior, this is built in to VSCode itself. You 
         "createTestFile.nameTemplate": "{filename}.test" // For javascript, if file is foo.js, will create foo.test.js
     }
 },
+// NOTE: Only the first rule to match the file path will be used!
+// Rules will be searched in the order they are defined.
 "createTestFile.pathMaps": [
     {
         // Defines rule such that any file under app/ will have a test file created under spec/
-        // Rules will be applied in the order they are defined. The first rule to match the file path will be used.
         "pathPattern": "app/?(.*)?", // Regex file path matcher
         "testFilePathPattern": "spec/$1" // $1, $2, etc. will be replaced with the matching text from the pathPattern
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "create-test-file",
   "displayName": "Create Test File at Path",
   "description": "Find or create empty test file with inferred location",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "publisher": "klondikemarlen",
   "repository": "https://github.com/klondikemarlen/vscode-create-test-file",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "create-test-file",
   "displayName": "Create Test File at Path",
   "description": "Find or create empty test file with inferred location",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "publisher": "klondikemarlen",
   "repository": "https://github.com/klondikemarlen/vscode-create-test-file",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js",
     "clean": "rm -rf ./out",
-    "clean:tmp": "rm -rf ./out/tmp"
+    "clean:tmp": "rm -rf ./out/tmp",
+    "clean:vsix": "rm *.vsix"
   },
   "devDependencies": {
     "@types/vscode": "^1.79.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
-    "test": "node ./out/test/runTest.js"
+    "test": "node ./out/test/runTest.js",
+    "clean": "rm -rf ./out"
   },
   "devDependencies": {
     "@types/vscode": "^1.79.0",

--- a/package.json
+++ b/package.json
@@ -96,10 +96,12 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "pretest": "npm run compile && npm run lint",
+    "pretest": "npm run compile && npm run lint && npm run pretest:workspace",
+    "pretest:workspace": "mkdir -p ./out/tmp && cp -r ./src/test/example-workspace ./out/tmp/",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js",
-    "clean": "rm -rf ./out"
+    "clean": "rm -rf ./out",
+    "clean:tmp": "rm -rf ./out/tmp"
   },
   "devDependencies": {
     "@types/vscode": "^1.79.0",

--- a/src/createTestFile.ts
+++ b/src/createTestFile.ts
@@ -36,11 +36,19 @@ export function testPath(srcPath: string,
 }
 
 function inferTestUri(srcUri: vscode.Uri): Thenable<vscode.Uri> {
-    const absolutePath = srcUri.path;
     return getExtensionSettings(srcUri).then((settings: ExtensionConfiguration) => {
         const nameTemplate = settings.get('nameTemplate');
-        const pathMapper = matchingPathMap(absolutePath, settings);
-        return srcUri.with({ path: testPath(absolutePath, nameTemplate, pathMapper) });
+
+        const absolutePath = srcUri.path;
+        const relativePath = vscode.workspace.asRelativePath(absolutePath);
+        const replaceLastMatchPattern = new RegExp(relativePath + '$');
+        const workspaceRootPath = absolutePath.replace(replaceLastMatchPattern, '');
+
+        const pathMapper = matchingPathMap(relativePath, settings);
+        const replacedPath = testPath(relativePath, nameTemplate, pathMapper);
+
+        const path = workspaceRootPath + replacedPath;
+        return srcUri.with({ path });
     });
 }
 

--- a/src/test/example-workspace/.vscode/settings.json
+++ b/src/test/example-workspace/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "createTestFile.nameTemplate": "{filename}.test"
+}

--- a/src/test/example-workspace/deep/example.rb
+++ b/src/test/example-workspace/deep/example.rb
@@ -1,0 +1,1 @@
+# src/test/example-workspace/deep/example.rb

--- a/src/test/example-workspace/example.js
+++ b/src/test/example-workspace/example.js
@@ -1,0 +1,1 @@
+# src/test/example-workspace/example.js

--- a/src/test/example-workspace/example.rb
+++ b/src/test/example-workspace/example.rb
@@ -1,0 +1,1 @@
+# src/test/example-workspace/example.rb

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -22,6 +22,9 @@ async function main() {
 				workspacePath,
 				'--disable-extensions'
 			],
+			extensionTestsEnv: {
+				workspaceRoot: workspacePath,
+			}
 		});
 	} catch (err) {
 		console.error('Failed to run tests', err);

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -12,11 +12,16 @@ async function main() {
 		// Passed to --extensionTestsPath
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
+		const workspacePath = path.resolve(__dirname, './example-workspace');
+
 		// Download VS Code, unzip it and run the integration test
 		await runTests({
 			extensionDevelopmentPath,
 			extensionTestsPath,
-			launchArgs: ['--disable-extensions'],
+			launchArgs: [
+				workspacePath,
+				'--disable-extensions'
+			],
 		});
 	} catch (err) {
 		console.error('Failed to run tests', err);

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -12,7 +12,7 @@ async function main() {
 		// Passed to --extensionTestsPath
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
-		const workspacePath = path.resolve(__dirname, './example-workspace');
+		const workspacePath = path.resolve(extensionDevelopmentPath, 'out/tmp/example-workspace');
 
 		// Download VS Code, unzip it and run the integration test
 		await runTests({

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -13,7 +13,11 @@ async function main() {
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
 		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath });
+		await runTests({
+			extensionDevelopmentPath,
+			extensionTestsPath,
+			launchArgs: ['--disable-extensions'],
+		});
 	} catch (err) {
 		console.error('Failed to run tests', err);
 		process.exit(1);

--- a/src/test/suite/createTestFile.test.ts
+++ b/src/test/suite/createTestFile.test.ts
@@ -9,25 +9,27 @@ import { createTestFile, testPath } from '../../createTestFile';
 const WORKSPACE_ROOT = process.env.workspaceRoot as string;
 
 suite('createTestFile', () => {
-	setup(async () => {
-		const config = vscode.workspace.getConfiguration(
-			'createTestFile',
-		);
-		await config.update('nameTemplate', '{filename}.test');
-		await config.update('pathMaps', []);
-		await config.update('languages', {});
+	suite('when only the name template is set', () => {
+		setup(async () => {
+			const config = vscode.workspace.getConfiguration(
+				'createTestFile',
+			);
+			await config.update('nameTemplate', '{filename}.test');
+			await config.update('pathMaps', []);
+			await config.update('languages', {});
 
-		const testFileExamplePath = path.join(WORKSPACE_ROOT, 'example.test.rb');
-		fs.unlink(testFileExamplePath, error => null);
-	});
+			const testFileExamplePath = path.join(WORKSPACE_ROOT, 'example.test.rb');
+			fs.unlink(testFileExamplePath, error => null);
+		});
 
-	test('should create the appropriate a test file', async () => {
-		const examplePath = path.join(WORKSPACE_ROOT, './example.rb');
-		const originalUri = vscode.Uri.file(examplePath);
+		test('performs a simple file name replacement', async () => {
+			const examplePath = path.join(WORKSPACE_ROOT, './example.rb');
+			const originalUri = vscode.Uri.file(examplePath);
 
-		const newUri = await createTestFile(originalUri);
-		const expected = path.join(WORKSPACE_ROOT, './example.test.rb');
-		assert.equal(expected, newUri.path);
+			const newUri = await createTestFile(originalUri);
+			const expected = path.join(WORKSPACE_ROOT, './example.test.rb');
+			assert.equal(expected, newUri.path);
+		});
 	});
 });
 

--- a/src/test/suite/createTestFile.test.ts
+++ b/src/test/suite/createTestFile.test.ts
@@ -1,6 +1,38 @@
 import * as assert from 'assert';
+import * as vscode from 'vscode';
 
-import { testPath } from '../../createTestFile';
+import * as path from 'path';
+import * as fs from 'fs';
+
+import { createTestFile, testPath } from '../../createTestFile';
+
+const WORKSPACE_ROOT = path.resolve(__dirname, '../example-workspace');
+
+suite('createTestFile', () => {
+	setup(() => {
+		const testFileExamplePath = path.join(WORKSPACE_ROOT, 'test_example.js');
+		return fs.unlink(
+			testFileExamplePath,
+			error => {
+				if (error) {
+				  throw error;
+				}
+
+				console.log(`${testFileExamplePath} is deleted.`);
+			  }
+		);
+	});
+
+	test('should create the appropriate a test file', () => {
+		const examplePath = path.join(WORKSPACE_ROOT, './example.js');
+		const originalUri = vscode.Uri.file(examplePath);
+
+		return createTestFile(originalUri).then(newUri => {
+			const expected = path.join(WORKSPACE_ROOT, './test_example.js');
+			assert.equal(expected, newUri.path);
+		});
+	});
+});
 
 
 suite('testPath', () => {

--- a/src/test/suite/createTestFile.test.ts
+++ b/src/test/suite/createTestFile.test.ts
@@ -10,12 +10,12 @@ const WORKSPACE_ROOT = process.env.workspaceRoot as string;
 
 suite('createTestFile', () => {
 	setup(() => {
-		const testFileExamplePath = path.join(WORKSPACE_ROOT, 'test_example.rb');
+		const testFileExamplePath = path.join(WORKSPACE_ROOT, 'example.test.rb');
 		return fs.unlink(testFileExamplePath, error => null);
 	});
 
 	teardown(() => {
-		const testFileExamplePath = path.join(WORKSPACE_ROOT, 'test_example.rb');
+		const testFileExamplePath = path.join(WORKSPACE_ROOT, 'example.test.rb');
 		return fs.unlink(testFileExamplePath, error => null);
 	});
 
@@ -24,15 +24,13 @@ suite('createTestFile', () => {
 			'createTestFile',
 		);
 
-		config.update('nameTemplate', '{filename}.test').then(() => {
-			console.log("config", config);
-
+		return config.update('nameTemplate', '{filename}.test').then(() => {
 			const examplePath = path.join(WORKSPACE_ROOT, './example.rb');
 			const originalUri = vscode.Uri.file(examplePath);
 
 			return createTestFile(originalUri).then(newUri => {
-				const expected = path.join(WORKSPACE_ROOT, './test_example.rb');
-				assert.equal(expected, newUri.path);
+				const expected = path.join(WORKSPACE_ROOT, './example.test.rb');
+				return assert.equal(expected, newUri.path);
 			});
 		});
 

--- a/src/test/suite/createTestFile.test.ts
+++ b/src/test/suite/createTestFile.test.ts
@@ -6,31 +6,36 @@ import * as fs from 'fs';
 
 import { createTestFile, testPath } from '../../createTestFile';
 
-const WORKSPACE_ROOT = path.resolve(__dirname, '../example-workspace');
+const WORKSPACE_ROOT = path.resolve(__dirname, '../../tmp/example-workspace');
 
 suite('createTestFile', () => {
 	setup(() => {
-		const testFileExamplePath = path.join(WORKSPACE_ROOT, 'test_example.js');
-		return fs.unlink(
-			testFileExamplePath,
-			error => {
-				if (error) {
-				  throw error;
-				}
+		const testFileExamplePath = path.join(WORKSPACE_ROOT, 'test_example.rb');
+		return fs.unlink(testFileExamplePath, error => null);
+	});
 
-				console.log(`${testFileExamplePath} is deleted.`);
-			  }
-		);
+	teardown(() => {
+		const testFileExamplePath = path.join(WORKSPACE_ROOT, 'test_example.rb');
+		return fs.unlink(testFileExamplePath, error => null);
 	});
 
 	test('should create the appropriate a test file', () => {
-		const examplePath = path.join(WORKSPACE_ROOT, './example.js');
-		const originalUri = vscode.Uri.file(examplePath);
+		const config = vscode.workspace.getConfiguration(
+			'createTestFile',
+		);
 
-		return createTestFile(originalUri).then(newUri => {
-			const expected = path.join(WORKSPACE_ROOT, './test_example.js');
-			assert.equal(expected, newUri.path);
+		config.update('nameTemplate', '{filename}.test').then(() => {
+			console.log("config", config);
+
+			const examplePath = path.join(WORKSPACE_ROOT, './example.rb');
+			const originalUri = vscode.Uri.file(examplePath);
+
+			return createTestFile(originalUri).then(newUri => {
+				const expected = path.join(WORKSPACE_ROOT, './test_example.rb');
+				assert.equal(expected, newUri.path);
+			});
 		});
+
 	});
 });
 

--- a/src/test/suite/createTestFile.test.ts
+++ b/src/test/suite/createTestFile.test.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 
 import { createTestFile, testPath } from '../../createTestFile';
 
-const WORKSPACE_ROOT = path.resolve(__dirname, '../../tmp/example-workspace');
+const WORKSPACE_ROOT = process.env.workspaceRoot as string;
 
 suite('createTestFile', () => {
 	setup(() => {

--- a/src/test/suite/createTestFile.test.ts
+++ b/src/test/suite/createTestFile.test.ts
@@ -1,0 +1,31 @@
+import * as assert from 'assert';
+
+import { testPath } from '../../createTestFile';
+
+
+suite('testPath', () => {
+	test('creates test file from windows path in same folder', () => {
+		const srcPath = '/c:/Users/bob/code/app/foo.rb';
+		const nameTemplate = '{filename}_spec';
+
+		const expected = '/c:/Users/bob/code/app/foo_spec.rb';
+		assert.equal(expected, testPath(srcPath, nameTemplate));
+	});
+
+	test('remaps windows path if mapping argument provided', () => {
+		const srcPath = '/c:/Users/bob/code/app/Foo.cs';
+		const nameTemplate = 'Test{filename}';
+		const pathMapper = { pathPattern: 'app(/?.*)', testFilePathPattern: 'spec$1' };
+
+		const expected = '/c:/Users/bob/code/spec/TestFoo.cs';
+		assert.equal(expected, testPath(srcPath, nameTemplate, pathMapper));
+	});
+
+	test('supports remaps relative to project folder', () => {
+		const srcPath = 'data/examples/example.rb';
+		const nameTemplate = '{filename}_spec';
+		const pathMapper = { pathPattern: '/?(.*)', testFilePathPattern: 'spec/$1' };
+		const expected = 'spec/data/examples/example_spec.rb';
+		assert.equal(expected, testPath(srcPath, nameTemplate, pathMapper));
+	});
+});

--- a/src/test/suite/createTestFile.test.ts
+++ b/src/test/suite/createTestFile.test.ts
@@ -9,31 +9,25 @@ import { createTestFile, testPath } from '../../createTestFile';
 const WORKSPACE_ROOT = process.env.workspaceRoot as string;
 
 suite('createTestFile', () => {
-	setup(() => {
-		const testFileExamplePath = path.join(WORKSPACE_ROOT, 'example.test.rb');
-		return fs.unlink(testFileExamplePath, error => null);
-	});
-
-	teardown(() => {
-		const testFileExamplePath = path.join(WORKSPACE_ROOT, 'example.test.rb');
-		return fs.unlink(testFileExamplePath, error => null);
-	});
-
-	test('should create the appropriate a test file', () => {
+	setup(async () => {
 		const config = vscode.workspace.getConfiguration(
 			'createTestFile',
 		);
+		await config.update('nameTemplate', '{filename}.test');
+		await config.update('pathMaps', []);
+		await config.update('languages', {});
 
-		return config.update('nameTemplate', '{filename}.test').then(() => {
-			const examplePath = path.join(WORKSPACE_ROOT, './example.rb');
-			const originalUri = vscode.Uri.file(examplePath);
+		const testFileExamplePath = path.join(WORKSPACE_ROOT, 'example.test.rb');
+		fs.unlink(testFileExamplePath, error => null);
+	});
 
-			return createTestFile(originalUri).then(newUri => {
-				const expected = path.join(WORKSPACE_ROOT, './example.test.rb');
-				return assert.equal(expected, newUri.path);
-			});
-		});
+	test('should create the appropriate a test file', async () => {
+		const examplePath = path.join(WORKSPACE_ROOT, './example.rb');
+		const originalUri = vscode.Uri.file(examplePath);
 
+		const newUri = await createTestFile(originalUri);
+		const expected = path.join(WORKSPACE_ROOT, './example.test.rb');
+		assert.equal(expected, newUri.path);
 	});
 });
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -3,36 +3,18 @@ import * as assert from 'assert';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
-import { testPath } from '../../createTestFile';
 
 suite('Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
-	suite('testPath', () => {
-		test('creates test file from windows path in same folder', () => {
-			const srcPath = '/c:/Users/bob/code/app/foo.rb';
-			const nameTemplate = '{filename}_spec';
+	test('extension activates without crashing', () => {
+		const extension = vscode.extensions.getExtension('klondikemarlen.create-test-file');
 
-			const expected = '/c:/Users/bob/code/app/foo_spec.rb';
-			assert.equal(expected, testPath(srcPath, nameTemplate));
-		});
+		assert.ok(extension !== undefined, "Extension is undefined");
+		const typedExtension = extension as vscode.Extension<any>;
 
-		test('remaps windows path if mapping argument provided', () => {
-			const srcPath = '/c:/Users/bob/code/app/Foo.cs';
-			const nameTemplate = 'Test{filename}';
-			const pathMapper = { pathPattern: 'app(/?.*)', testFilePathPattern: 'spec$1' };
-
-			const expected = '/c:/Users/bob/code/spec/TestFoo.cs';
-			assert.equal(expected, testPath(srcPath, nameTemplate, pathMapper));
-		});
-
-		test('supports remaps relative to project folder', () => {
-			const srcPath = '/home/user-name/vscode-create-test-file/data/examples/example.rb';
-			const nameTemplate = '{filename}_spec';
-			const pathMapper = { pathPattern: '(/home/user-name/vscode-create-test-file)/?(.*)', testFilePathPattern: '$1/spec/$2' };
-			const expected = '/home/user-name/vscode-create-test-file/spec/data/examples/example_spec.rb';
-			assert.equal(expected, testPath(srcPath, nameTemplate, pathMapper));
+		assert.doesNotThrow(() => {
+			typedExtension.activate();
 		});
 	});
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -13,8 +13,8 @@ suite('Extension Test Suite', () => {
 		assert.ok(extension !== undefined, "Extension is undefined");
 		const typedExtension = extension as vscode.Extension<any>;
 
-		assert.doesNotThrow(() => {
-			typedExtension.activate();
+		return assert.doesNotThrow(() => {
+			return typedExtension.activate();
 		});
 	});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,8 @@
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
 	},
+	"watchOptions": {
+		"excludeDirectories": ["**/node_modules", "./out"]
+	},
 	"exclude": ["./node_mdules", "./out", "./src/test/example-workspace"],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,11 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true   /* enable all strict type-checking options */
+		"strict": true,   /* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
-	}
+	},
+	"exclude": ["./node_mdules", "./out", "./src/test/example-workspace"],
 }


### PR DESCRIPTION
Fixes #1

# Context
Make path replacement relative so you don't need to include absolute paths in your replacement pattern to replace the top level component.
i.e.
```json
"createTestFile.nameTemplate": "{filename}_spec",
"createTestFile.pathMaps": [
  { "pathPattern": "/?(.*)", "testFilePathPattern": "spec/$1" }
]
```

Given a directory `/some/workspace/directory` and a file `/some/file/path.rb`, this pattern would create the file
```
/some/workspace/directory/spec/some/file/path_spec.rb
```

# Extras

Set up an end-to-end test pipeline, and add some e2e tests.