### PR TITLE
Issue 2: Add Support for Filename Extension Replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [3.0.0] - 2023-06-30
+
+- Added support for filename extension mutation.
+
 ## [2.0.1] - 2023-06-30
 
 - Improve readme.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ** This is a fork of https://github.com/paul-mannino/vscode-create-test-file **
 
-Published to https://marketplace.visualstudio.com/items?itemName=klondikemarlen.create-test-file
-
 This is an extension that adds a command for creating a test file, with a given name and path inferred from a currently open file (or one selected file from the sidebar).
 
 For example, if your application code lives under the `app` directory in your workspace and your test code lives under the `spec` folder, you can define rules such that for any file `app/foo/bar/filename.rb`, you will create or open a file with `spec/foo/bar/filename_spec.rb`. These settings can be customized for each filetype, and you may create multiple
@@ -70,3 +68,5 @@ See https://code.visualstudio.com/api/working-with-extensions/publishing-extensi
 3. `vsce publish`
 
 > You might need to periodically refresh your azure dev ops api key.
+
+Published to https://marketplace.visualstudio.com/items?itemName=klondikemarlen.create-test-file

--- a/README.md
+++ b/README.md
@@ -10,9 +10,19 @@ path mappers if you have multiple conventions for where you create tests.
 ## Features
 
 Full path mutation support via JS regex replace.
-Given an absolute path, a path pattern and a test file pattern, you get `absolutePath.replace(pathPattern, testFilePattern)`; anything you can write via https://regex101.com/ will work.
+Given a path pattern and a test file pattern, you get `workspaceRelativePath.replace(pathPattern, testFilePattern)`; anything you can write via https://regex101.com/ will work.
 
-If you want workspace specific behavior, this is built in to VSCode itself. You can activate this feature by editing appropriate settings in the project relative `./.vscode/settings.json` file.
+Pattern matched filename mutatation. Format is `{filename}.{extension}` both filename and extension are optional. So if you want to change the extension completely you could do
+```json
+"createTestFile.languages": {
+    "[vue]": {
+        "createTestFile.nameTemplate": "{filename}.test.js"
+    }
+}
+```
+which for Vue.js files, if file is foo.vue, will create foo.test.js
+
+If you want workspace specific behavior, this is built in to VSCode itself. You can activate this feature by editing appropriate settings in the project relative `./.vscode/settings.json` file. See https://code.visualstudio.com/docs/getstarted/settings#_workspace-settings
 
 ## Extension Settings
 
@@ -20,10 +30,10 @@ For pattern replacement conventions see [Specifying a string as the replacement]
 
 ```javascript -- instead of json to support comments
 // Basic settings
-"createTestFile.nameTemplate": "{filename}_spec", // If file is named foo.bar, will create test named foo_spec.bar
+"createTestFile.nameTemplate": "{filename}_spec.{extension}", // If file is named foo.bar, will create test named foo_spec.bar
 "createTestFile.languages": {
     "[javascript]": {
-        "createTestFile.nameTemplate": "{filename}.test" // For javascript, if file is foo.js, will create foo.test.js
+        "createTestFile.nameTemplate": "{filename}.test.{extension}" // For javascript, if file is foo.js, will create foo.test.js
     }
 },
 // NOTE: Only the first rule to match the file path will be used!
@@ -41,16 +51,20 @@ For pattern replacement conventions see [Specifying a string as the replacement]
 
 While path replacement has full regex support, filename replacement **does not** support full regex replacement.
 
+Why didn't I make filename replacement support full regex? Because the regex pattern for parsing out the file extension would need be more complex than `/^(\/?|)([\s\S]*?)((?:\.{1,2}|[^\/]+?|)(\.[^.\/]*|))(?:[\/]*)$/` See https://github.com/jinder/path/blob/7fbaede3ca9d224494cbdd47d7ca803ee96d2055/path.js#L420 and https://github.com/jinder/path/blob/7fbaede3ca9d224494cbdd47d7ca803ee96d2055/path.js#L91
+
 ## Release Notes
 
 See [CHANGELOG](./CHANGELOG.md)
 
-## Development
+## Development and Testing
 
 Generally you would run the project via F5 in VSCode.
 
-Alternatively, see package.json -> scripts other commands.
-- npm run test
+Alternatively, see [package.json](./package.json) -> `scripts` for other commands.
+
+e.g.
+- `npm run test`
 
 ### File Access in Tests
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
       "properties": {
         "createTestFile.nameTemplate": {
           "type": "string",
-          "default": "test_{filename}",
+          "default": "test_{filename}.{extension}",
           "description": "Template for filename of created test files"
         },
         "createTestFile.pathMaps": {
@@ -82,7 +82,7 @@
               "properties": {
                 "createTestFile.nameTemplate": {
                   "type": "string",
-                  "default": "test_{filename}",
+                  "default": "test_{filename}.{extension}",
                   "description": "Template for filename of created test files"
                 }
               }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "create-test-file",
   "displayName": "Create Test File at Path",
   "description": "Find or create empty test file with inferred location",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "publisher": "klondikemarlen",
   "repository": "https://github.com/klondikemarlen/vscode-create-test-file",
   "engines": {

--- a/src/createTestFile.ts
+++ b/src/createTestFile.ts
@@ -25,14 +25,19 @@ export function findTestFile(srcUri: vscode.Uri): Thenable<vscode.TextDocument> 
 export function testPath(srcPath: string,
                          nameTemplate: string,
                          pathMap?: PathMap): string {
-    let ext = path.extname(srcPath);
-    let file = path.basename(srcPath, ext);
-    let dir = path.dirname(srcPath);
+    let directory = path.dirname(srcPath);
     if (typeof pathMap !== 'undefined') {
-        dir = destPath(dir, pathMap);
+        directory = destPath(directory, pathMap);
     }
-    let testBasename = nameTemplate.replace('{filename}', file) + ext;
-    return path.posix.join(dir, testBasename);
+
+    const extension = path.extname(srcPath);
+    const filename = path.basename(srcPath, extension);
+    let testBasename = nameTemplate.replace('{filename}', filename);
+
+    const extensionWithoutDot = extension.slice(1);
+    testBasename = testBasename.replace('{extension}', extensionWithoutDot);
+
+    return path.posix.join(directory, testBasename);
 }
 
 function inferTestUri(srcUri: vscode.Uri): Thenable<vscode.Uri> {

--- a/src/extensionConfiguration.ts
+++ b/src/extensionConfiguration.ts
@@ -5,7 +5,7 @@ interface IConfig {
 }
 
 const DEFAULT_CONFIG: IConfig = {
-    nameTemplate: '{filename}_spec',
+    nameTemplate: '{filename}_spec.{extension}',
     locationMaps: []
 };
 

--- a/src/test/example-workspace/.vscode/settings.json
+++ b/src/test/example-workspace/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "createTestFile.nameTemplate": "{filename}.test"
+    "createTestFile.nameTemplate": "{filename}.test.{extension}"
 }

--- a/src/test/suite/createTestFile.test.ts
+++ b/src/test/suite/createTestFile.test.ts
@@ -14,7 +14,7 @@ suite('createTestFile', () => {
 			const config = vscode.workspace.getConfiguration(
 				'createTestFile',
 			);
-			await config.update('nameTemplate', '{filename}.test');
+			await config.update('nameTemplate', '{filename}.test.{extension}');
 			await config.update('pathMaps', []);
 			await config.update('languages', {});
 
@@ -38,7 +38,7 @@ suite('createTestFile', () => {
 			const config = vscode.workspace.getConfiguration(
 				'createTestFile',
 			);
-			await config.update('nameTemplate', '{filename}.test');
+			await config.update('nameTemplate', '{filename}.test.{extension}');
 			await config.update('pathMaps', [
 				{
 					"pathPattern": "/?(.*)",
@@ -67,13 +67,13 @@ suite('createTestFile', () => {
 			const config = vscode.workspace.getConfiguration(
 				'createTestFile',
 			);
-			await config.update('nameTemplate', '{filename}.test');
+			await config.update('nameTemplate', '{filename}.test.{extension}');
 			await config.update('pathMaps', []);
 			await config.update('languages', {
 				// eslint-disable-next-line @typescript-eslint/naming-convention
 				"[ruby]": {
 					// eslint-disable-next-line @typescript-eslint/naming-convention
-					"createTestFile.nameTemplate": "{filename}_spec"
+					"createTestFile.nameTemplate": "{filename}_spec.{extension}"
 				}
 			});
 
@@ -97,7 +97,7 @@ suite('createTestFile', () => {
 suite('testPath', () => {
 	test('creates test file from windows path in same folder', () => {
 		const srcPath = '/c:/Users/bob/code/app/foo.rb';
-		const nameTemplate = '{filename}_spec';
+		const nameTemplate = '{filename}_spec.{extension}';
 
 		const expected = '/c:/Users/bob/code/app/foo_spec.rb';
 		assert.equal(expected, testPath(srcPath, nameTemplate));
@@ -105,7 +105,7 @@ suite('testPath', () => {
 
 	test('remaps windows path if mapping argument provided', () => {
 		const srcPath = '/c:/Users/bob/code/app/Foo.cs';
-		const nameTemplate = 'Test{filename}';
+		const nameTemplate = 'Test{filename}.{extension}';
 		const pathMapper = { pathPattern: 'app(/?.*)', testFilePathPattern: 'spec$1' };
 
 		const expected = '/c:/Users/bob/code/spec/TestFoo.cs';
@@ -114,9 +114,17 @@ suite('testPath', () => {
 
 	test('supports remaps relative to project folder', () => {
 		const srcPath = 'data/examples/example.rb';
-		const nameTemplate = '{filename}_spec';
+		const nameTemplate = '{filename}_spec.{extension}';
 		const pathMapper = { pathPattern: '/?(.*)', testFilePathPattern: 'spec/$1' };
 		const expected = 'spec/data/examples/example_spec.rb';
+		assert.equal(expected, testPath(srcPath, nameTemplate, pathMapper));
+	});
+
+	test('supports setting a completely different extension', () => {
+		const srcPath = 'data/examples/example.vue';
+		const nameTemplate = '{filename}.test.js';
+		const pathMapper = { pathPattern: '/?(.*)', testFilePathPattern: 'spec/$1' };
+		const expected = 'spec/data/examples/example.test.js';
 		assert.equal(expected, testPath(srcPath, nameTemplate, pathMapper));
 	});
 });


### PR DESCRIPTION
Fixes #2

# Context

Add support for filename extension mutation.

Why? So you can create test files for `.vue` files with a pattern something like `file-name.vue` -> `file-name.vue.test.js`

This requires changing the stock settings configuration to support an extension replacement pattern.
e.g.
```json
"createTestFile.nameTemplate": "{filename}.test"
```
becomes
```json
"createTestFile.nameTemplate": "{filename}.test.{extension}"
```