### PR TITLE
Issue 3: Add Support for Switching Between Test and Non Test Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [3.1.0] - 2023-06-30
+
+- Add support for switching between test and non-test files.
+
 ## [3.0.0] - 2023-06-30
 
 - Added support for filename extension mutation.

--- a/README.md
+++ b/README.md
@@ -7,12 +7,23 @@ This is an extension that adds a command for creating a test file, with a given 
 For example, if your application code lives under the `app` directory in your workspace and your test code lives under the `spec` folder, you can define rules such that for any file `app/foo/bar/filename.rb`, you will create or open a file with `spec/foo/bar/filename_spec.rb`. These settings can be customized for each filetype, and you may create multiple
 path mappers if you have multiple conventions for where you create tests.
 
+Available commands are:
+- Create Test File: Create Test File
+- Create Test File: Find Test File
+- Create Test File: Go To or From Test File
+- Create Test File: Clean Go to or From Cache
+
+Suggested keyboard shortcut:
+- `ctrl+shift+u`
+
+> If you are using ubuntu you will need to disable the ibus emoji macro to free up this shortcut. See https://superuser.com/a/1392682/150253
+
 ## Features
 
-Full path mutation support via JS regex replace.
+1. Full path mutation support via JS regex replace.
 Given a path pattern and a test file pattern, you get `workspaceRelativePath.replace(pathPattern, testFilePattern)`; anything you can write via https://regex101.com/ will work.
 
-Pattern matched filename mutatation. Format is `{filename}.{extension}` both filename and extension are optional. So if you want to change the extension completely you could do
+2. Pattern matched filename mutatation. Format is `{filename}.{extension}` both filename and extension are optional. So if you want to change the extension completely you could do
 ```json
 "createTestFile.languages": {
     "[vue]": {
@@ -22,7 +33,9 @@ Pattern matched filename mutatation. Format is `{filename}.{extension}` both fil
 ```
 which for Vue.js files, if file is foo.vue, will create foo.test.js
 
-If you want workspace specific behavior, this is built in to VSCode itself. You can activate this feature by editing appropriate settings in the project relative `./.vscode/settings.json` file. See https://code.visualstudio.com/docs/getstarted/settings#_workspace-settings
+3. If you want workspace specific behavior, this is built in to VSCode itself. You can activate this feature by editing appropriate settings in the project relative `./.vscode/settings.json` file. See https://code.visualstudio.com/docs/getstarted/settings#_workspace-settings
+
+4. Quick swapping between test and non-test files. This is still a work in progress! **You will get an error if you try to swap, and start from the test file.** To safely use this feature you need to start from a non-test file, then trigger the "Go to or from test file" action. After that, the connection between the test and non-test file will be established, an you can swap between the two files.
 
 ## Extension Settings
 
@@ -59,9 +72,11 @@ isTestFileMatchers: [
 
 ## Known Issues
 
-While path replacement has full regex support, filename replacement **does not** support full regex replacement.
+1. While path replacement has full regex support, filename replacement **does not** support full regex replacement.
 
 Why didn't I make filename replacement support full regex? Because the regex pattern for parsing out the file extension would need be more complex than `/^(\/?|)([\s\S]*?)((?:\.{1,2}|[^\/]+?|)(\.[^.\/]*|))(?:[\/]*)$/` See https://github.com/jinder/path/blob/7fbaede3ca9d224494cbdd47d7ca803ee96d2055/path.js#L420 and https://github.com/jinder/path/blob/7fbaede3ca9d224494cbdd47d7ca803ee96d2055/path.js#L91
+
+2. You will get an error if you try to swap to a source file, and you start from the test file. Future work will either provide a fuzzy search and a quick pick list of possible source files from a given test file, or will reduce the path replacement complexity until path replacement becomes a fully reversible process.
 
 ## Release Notes
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ For pattern replacement conventions see [Specifying a string as the replacement]
         "pathPattern": "app/?(.*)?", // Regex file path matcher
         "testFilePathPattern": "spec/$1" // $1, $2, etc. will be replaced with the matching text from the pathPattern
     }
+],
+// Matchers that determine whether a file is a test file or not.
+// You probably don't need to edit this, but if you need to you can.
+isTestFileMatchers: [
+    "^(?:test|spec)s?/", // matches paths that start with either "test" or "spec" followed by an optional "s", and finally ending with a forward slash "/"
+    "/(?:test|spec)s?/", // matches paths that have a segment of test(s) or spec(s) and is bracketed with forward slashes "/"
+    "/?(?:test|spec)s?_",  // matches paths that start an optional forward slash "/" then with either "test" or "spec" followed by an optional "s", and finally ending with a _
+    "/?_(?:test|spec)s?", // same as above, but leading "_"
+    "/?\\.(?:test|spec)s?", // same as above but with leading "."
+    "/?(?:test|spec)s?\\." // same as above but with trailing "."
 ]
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-test-file",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-test-file",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "devDependencies": {
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-test-file",
-  "version": "1.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-test-file",
-      "version": "1.1.0",
+      "version": "3.0.0",
       "devDependencies": {
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
       },
       {
         "command": "vscode-create-test-file.cleanCache",
-        "title": "Clean to to or from cache.",
+        "title": "Clean Go to or From Cache",
         "category": "Create Test File"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "vscode": "^1.79.0"
   },
   "categories": [
+    "Testing",
     "Other"
   ],
+  "keywords": ["create", "swap", "go", "test", "file"],
   "activationEvents": [],
   "main": "./out/extension.js",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
         "title": "Find Test File"
       },
       {
-        "command": "vscode-create-test-file.helloWorld",
-        "title": "Hello World"
+        "command": "vscode-create-test-file.goToOrFromTest",
+        "title": "Go To or From Test File"
       }
     ],
     "menus": {
@@ -39,6 +39,10 @@
         {
           "command": "vscode-create-test-file.findTestFile",
           "when": "!explorerResourceIsFolder"
+        },
+        {
+          "command": "vscode-create-test-file.goToOrFromTest",
+          "when": "!explorerResourceIsFolder"
         }
       ],
       "editor/title/context": [
@@ -47,6 +51,9 @@
         },
         {
           "command": "vscode-create-test-file.findTestFile"
+        },
+        {
+          "command": "vscode-create-test-file.goToOrFromTest"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "create-test-file",
   "displayName": "Create Test File at Path",
   "description": "Find or create empty test file with inferred location",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "publisher": "klondikemarlen",
   "repository": "https://github.com/klondikemarlen/vscode-create-test-file",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -19,19 +19,23 @@
     "commands": [
       {
         "command": "vscode-create-test-file.createTestFile",
-        "title": "Create Test File"
+        "title": "Create Test File",
+        "category": "Create Test File"
       },
       {
         "command": "vscode-create-test-file.findTestFile",
-        "title": "Find Test File"
+        "title": "Find Test File",
+        "category": "Create Test File"
       },
       {
         "command": "vscode-create-test-file.goToOrFromTest",
-        "title": "Go To or From Test File"
+        "title": "Go To or From Test File",
+        "category": "Create Test File"
       },
       {
         "command": "vscode-create-test-file.cleanCache",
-        "title": "Clean test to source and source to test lookup cache."
+        "title": "Clean to to or from cache.",
+        "category": "Create Test File"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
       {
         "command": "vscode-create-test-file.goToOrFromTest",
         "title": "Go To or From Test File"
+      },
+      {
+        "command": "vscode-create-test-file.cleanCache",
+        "title": "Clean test to source and source to test lookup cache."
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,21 @@
               }
             }
           }
+        },
+        "createTestFile.isTestFileMatchers": {
+          "type": "array",
+          "default": [
+            "^(?:test|spec)s?/",
+            "/(?:test|spec)s?/",
+            "/?(?:test|spec)s?_",
+            "/?_(?:test|spec)s?",
+            "/?\\.(?:test|spec)s?",
+            "/?(?:test|spec)s?\\."
+          ],
+          "description": "List of regular expressions used to detect if a file is a test file",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }

--- a/src/cacheKeyConstants.ts
+++ b/src/cacheKeyConstants.ts
@@ -1,0 +1,2 @@
+export const SOURCE_TO_TEST_MAP_KEY = 'sourceToTestMap';
+export const TEST_TO_SOURCE_MAP_KEY = 'testToSourceMap';

--- a/src/cleanCache.ts
+++ b/src/cleanCache.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+
+import { TEST_TO_SOURCE_MAP_KEY, SOURCE_TO_TEST_MAP_KEY } from './cacheKeyConstants';
+
+export function cleanCache(extensionContext: vscode.ExtensionContext): Thenable<Boolean> {
+    const workspaceState = extensionContext.workspaceState;
+    return workspaceState
+        .update(TEST_TO_SOURCE_MAP_KEY, undefined)
+        .then(() => workspaceState.update(SOURCE_TO_TEST_MAP_KEY, undefined))
+        .then(() => true);
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,11 +1,22 @@
 import * as vscode from 'vscode';
 
-import { goToOrFromTest } from './goToFromTest';
+import { cleanCache } from './cleanCache';
 import { createTestFile, findTestFile } from './createTestFile';
+import { goToOrFromTest } from './goToFromTest';
 
 const NO_URI_ERROR = (action: string): string => {
     return `Cannot ${action} spec file. File must be open in editor or selected in file explorer.`;
 };
+
+export function cleanCacheCommand(extensionContext: vscode.ExtensionContext): vscode.Disposable {
+    return vscode.commands.registerCommand('vscode-create-test-file.cleanCache', () => {
+        return cleanCache(extensionContext).then(() => {
+            vscode.window.showInformationMessage('Cleared cache.');
+        }, () => {
+            vscode.window.showErrorMessage('Failed to cleared cache.');
+        });
+    });
+}
 
 export function goOrToFromTestCommand(extensionContext: vscode.ExtensionContext): vscode.Disposable {
     return vscode.commands.registerCommand('vscode-create-test-file.goToOrFromTest', (uri) => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,9 +1,26 @@
 import * as vscode from 'vscode';
+
+import { goToOrFromTest } from './goToFromTest';
 import { createTestFile, findTestFile } from './createTestFile';
 
 const NO_URI_ERROR = (action: string): string => {
     return `Cannot ${action} spec file. File must be open in editor or selected in file explorer.`;
 };
+
+export function goOrToFromTestCommand(extensionContext: vscode.ExtensionContext): vscode.Disposable {
+    return vscode.commands.registerCommand('vscode-create-test-file.goToOrFromTest', (uri) => {
+        const sourceUri = ensureUri(uri);
+
+        if (!sourceUri) {
+            vscode.window.showErrorMessage(NO_URI_ERROR('go to or from'));
+            return;
+        }
+
+        goToOrFromTest(extensionContext, sourceUri).then((destinationUri) => {
+            vscode.window.showTextDocument(destinationUri);
+        });
+    });
+}
 
 export function createTestCommand(): vscode.Disposable {
     return vscode.commands.registerCommand('vscode-create-test-file.createTestFile', (uri) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,29 +2,21 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
-import { findTestCommand, createTestCommand } from './commands';
+import { findTestCommand, createTestCommand, goOrToFromTestCommand } from './commands';
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	// console.log('Congratulations, your extension "vscode-create-test-file" is now active!');
-
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with registerCommand
 	// The commandId parameter must match the command field in package.json
-	// const disposable = vscode.commands.registerCommand('vscode-create-test-file.helloWorld', () => {
-	// 	// The code you place here will be executed every time your command is executed
-	// 	// Display a message box to the user
-	// 	vscode.window.showInformationMessage('Hello World from Create Test File!');
-	// });
-
-	// context.subscriptions.push(disposable);
+	context.subscriptions.push(goOrToFromTestCommand(context));
 	context.subscriptions.push(createTestCommand());
     context.subscriptions.push(findTestCommand());
 }
 
 // This method is called when your extension is deactivated
 // eslint-disable-next-line @typescript-eslint/no-empty-function
-export function deactivate() {}
+export function deactivate() {
+	// clean up cache files?
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
-import { findTestCommand, createTestCommand, goOrToFromTestCommand } from './commands';
+import { cleanCacheCommand, findTestCommand, createTestCommand, goOrToFromTestCommand } from './commands';
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -10,6 +10,7 @@ export function activate(context: vscode.ExtensionContext) {
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with registerCommand
 	// The commandId parameter must match the command field in package.json
+	context.subscriptions.push(cleanCacheCommand(context));
 	context.subscriptions.push(goOrToFromTestCommand(context));
 	context.subscriptions.push(createTestCommand());
     context.subscriptions.push(findTestCommand());

--- a/src/goToFromTest.ts
+++ b/src/goToFromTest.ts
@@ -1,10 +1,51 @@
 import * as vscode from 'vscode';
 
-export function goToOrFromTest(context: vscode.ExtensionContext, srcUri: vscode.Uri): Thenable<vscode.Uri> {
+import { createTestFile } from './createTestFile';
 
-    return Promise.resolve(srcUri);
+export function goToOrFromTest(extensionContext: vscode.ExtensionContext, sourceUri: vscode.Uri): Thenable<vscode.Uri> {
+
+    if (isTestFile(extensionContext, sourceUri)) {
+        const destinationUri = goToSource(extensionContext, sourceUri);
+        return Promise.resolve(destinationUri);
+    } else {
+        return goToTest(extensionContext, sourceUri);
+    }
 }
 
-// Cache lookup
-//
-// context.workspaceState:
+export function isTestFile(extensionContext: vscode.ExtensionContext, sourceUri: vscode.Uri): boolean {
+    const workspaceState = extensionContext.workspaceState;
+
+    // if entry found that links this file to a source file
+    // then the file is a test file
+    if (workspaceState.get(`test-to-source-map:${sourceUri.path}`)) {
+        return true;
+    }
+
+    return false;
+}
+
+export function goToSource(extensionContext: vscode.ExtensionContext, sourceUri: vscode.Uri): vscode.Uri {
+    const workspaceState = extensionContext.workspaceState;
+    const destinationPath = workspaceState.get(`test-to-source-map:${sourceUri.path}`) as string;
+    if (destinationPath) {
+        const destinationUri = vscode.Uri.file(destinationPath);
+        return destinationUri;
+    }
+    vscode.window.showErrorMessage('Could not find a source file for this test file.');
+    return sourceUri;
+}
+
+export function goToTest(extensionContext: vscode.ExtensionContext, sourceUri: vscode.Uri): Thenable<vscode.Uri> {
+    const workspaceState = extensionContext.workspaceState;
+    const destinationPath = workspaceState.get(`source-to-test-map:${sourceUri.path}`) as string;
+    if (destinationPath) {
+        const destinationUri = vscode.Uri.file(destinationPath);
+        return Promise.resolve(destinationUri);
+    }
+
+    return createTestFile(sourceUri).then(destinationUri => {
+        workspaceState.update(`source-to-test-map:${sourceUri.path}`, destinationUri.path);
+        workspaceState.update(`test-to-source-map:${destinationUri.path}`, sourceUri.path);
+        return destinationUri;
+    });
+}

--- a/src/goToFromTest.ts
+++ b/src/goToFromTest.ts
@@ -1,6 +1,9 @@
 import * as vscode from 'vscode';
 
 import { createTestFile } from './createTestFile';
+import { TEST_TO_SOURCE_MAP_KEY, SOURCE_TO_TEST_MAP_KEY } from './cacheKeyConstants';
+
+type PathMap = { [path: string]: string };
 
 export function goToOrFromTest(extensionContext: vscode.ExtensionContext, sourceUri: vscode.Uri): Thenable<vscode.Uri> {
     if (isTestFile(extensionContext, sourceUri)) {
@@ -13,10 +16,7 @@ export function goToOrFromTest(extensionContext: vscode.ExtensionContext, source
 
 export function isTestFile(extensionContext: vscode.ExtensionContext, sourceUri: vscode.Uri): boolean {
     const workspaceState = extensionContext.workspaceState;
-
-    // if entry found that links this file to a source file
-    // then the file is a test file
-    if (workspaceState.get(`test-to-source-map:${sourceUri.path}`)) {
+    if (pathExistsInCache(workspaceState, TEST_TO_SOURCE_MAP_KEY, sourceUri.path)) {
         return true;
     }
 
@@ -25,27 +25,30 @@ export function isTestFile(extensionContext: vscode.ExtensionContext, sourceUri:
 
 export function goToSource(extensionContext: vscode.ExtensionContext, sourceUri: vscode.Uri): vscode.Uri {
     const workspaceState = extensionContext.workspaceState;
-    const destinationPath = workspaceState.get(`test-to-source-map:${sourceUri.path}`) as string;
+    const sourcePath = sourceUri.path;
+    const destinationPath = getPathFromCache(workspaceState, TEST_TO_SOURCE_MAP_KEY, sourcePath);
     if (destinationPath) {
         const destinationUri = vscode.Uri.file(destinationPath);
         return destinationUri;
     }
-    vscode.window.showErrorMessage('Could not find a source file for this test file.');
+    vscode.window.showErrorMessage(`Could not find a source file for the test file: ${sourcePath}`);
     return sourceUri;
 }
 
 export function goToTest(extensionContext: vscode.ExtensionContext, sourceUri: vscode.Uri): Thenable<vscode.Uri> {
     const workspaceState = extensionContext.workspaceState;
-    const destinationPath = workspaceState.get(`source-to-test-map:${sourceUri.path}`) as string;
+    const sourcePath = sourceUri.path;
+    const destinationPath = getPathFromCache(workspaceState, SOURCE_TO_TEST_MAP_KEY, sourcePath);
     if (destinationPath) {
         const destinationUri = vscode.Uri.file(destinationPath);
         return Promise.resolve(destinationUri);
     }
 
-    return createTestFile(sourceUri).then(async destinationUri => {
-        await workspaceState.update(`source-to-test-map:${sourceUri.path}`, destinationUri.path);
-        await workspaceState.update(`test-to-source-map:${destinationUri.path}`, sourceUri.path);
-        return destinationUri;
+    return createTestFile(sourceUri).then((destinationUri) => {
+        const destinationPath = destinationUri.path;
+        return updateCache(workspaceState, sourcePath, destinationPath).then(
+            () => destinationUri
+        );
     });
 }
 
@@ -58,4 +61,24 @@ export function matchesTestFilePattern(sourceUri: vscode.Uri): boolean {
         const regex = new RegExp(matcher);
         return regex.test(sourcePath);
     });
+}
+
+export function updateCache(workspaceState: vscode.Memento, sourcePath: string, testPath: string): Thenable<void> {
+    const sourceToTestMap = workspaceState.get(SOURCE_TO_TEST_MAP_KEY, {}) as PathMap;
+    sourceToTestMap[sourcePath] = testPath;
+    return workspaceState.update(SOURCE_TO_TEST_MAP_KEY, sourceToTestMap).then(() => {
+        const testToSourceMap = workspaceState.get(TEST_TO_SOURCE_MAP_KEY, {}) as PathMap;
+        testToSourceMap[testPath] = sourcePath;
+        return workspaceState.update(TEST_TO_SOURCE_MAP_KEY, testToSourceMap);
+    });
+}
+
+export function pathExistsInCache(workspaceState: vscode.Memento, key: string, path: string): boolean {
+    const cache = workspaceState.get(key, {}) as PathMap;
+    return path in cache;
+}
+
+export function getPathFromCache(workspaceState: vscode.Memento, key: string, path: string): string {
+    const cache = workspaceState.get(key, {}) as PathMap;
+    return cache[path];
 }

--- a/src/goToFromTest.ts
+++ b/src/goToFromTest.ts
@@ -3,7 +3,6 @@ import * as vscode from 'vscode';
 import { createTestFile } from './createTestFile';
 
 export function goToOrFromTest(extensionContext: vscode.ExtensionContext, sourceUri: vscode.Uri): Thenable<vscode.Uri> {
-
     if (isTestFile(extensionContext, sourceUri)) {
         const destinationUri = goToSource(extensionContext, sourceUri);
         return Promise.resolve(destinationUri);
@@ -43,9 +42,9 @@ export function goToTest(extensionContext: vscode.ExtensionContext, sourceUri: v
         return Promise.resolve(destinationUri);
     }
 
-    return createTestFile(sourceUri).then(destinationUri => {
-        workspaceState.update(`source-to-test-map:${sourceUri.path}`, destinationUri.path);
-        workspaceState.update(`test-to-source-map:${destinationUri.path}`, sourceUri.path);
+    return createTestFile(sourceUri).then(async destinationUri => {
+        await workspaceState.update(`source-to-test-map:${sourceUri.path}`, destinationUri.path);
+        await workspaceState.update(`test-to-source-map:${destinationUri.path}`, sourceUri.path);
         return destinationUri;
     });
 }

--- a/src/goToFromTest.ts
+++ b/src/goToFromTest.ts
@@ -21,7 +21,7 @@ export function isTestFile(extensionContext: vscode.ExtensionContext, sourceUri:
         return true;
     }
 
-    return false;
+    return matchesTestFilePattern(sourceUri);
 }
 
 export function goToSource(extensionContext: vscode.ExtensionContext, sourceUri: vscode.Uri): vscode.Uri {
@@ -47,5 +47,16 @@ export function goToTest(extensionContext: vscode.ExtensionContext, sourceUri: v
         workspaceState.update(`source-to-test-map:${sourceUri.path}`, destinationUri.path);
         workspaceState.update(`test-to-source-map:${destinationUri.path}`, sourceUri.path);
         return destinationUri;
+    });
+}
+
+export function matchesTestFilePattern(sourceUri: vscode.Uri): boolean {
+    const config = vscode.workspace.getConfiguration('createTestFile');
+    const isTestFileMatchers = config.get('isTestFileMatchers') as string[];
+
+    const sourcePath = sourceUri.path;
+    return isTestFileMatchers.some((matcher: string) => {
+        const regex = new RegExp(matcher);
+        return regex.test(sourcePath);
     });
 }

--- a/src/goToFromTest.ts
+++ b/src/goToFromTest.ts
@@ -31,7 +31,10 @@ export function goToSource(extensionContext: vscode.ExtensionContext, sourceUri:
         const destinationUri = vscode.Uri.file(destinationPath);
         return destinationUri;
     }
-    vscode.window.showErrorMessage(`Could not find a source file for the test file: ${sourcePath}`);
+    vscode.window.showErrorMessage(
+        `Could not find a source file for the test file: "${sourcePath}".` +
+        ' Try going to the source file, then triggering "Go To or From Test File" and it should work after that.'
+    );
     return sourceUri;
 }
 

--- a/src/goToFromTest.ts
+++ b/src/goToFromTest.ts
@@ -1,0 +1,10 @@
+import * as vscode from 'vscode';
+
+export function goToOrFromTest(context: vscode.ExtensionContext, srcUri: vscode.Uri): Thenable<vscode.Uri> {
+
+    return Promise.resolve(srcUri);
+}
+
+// Cache lookup
+//
+// context.workspaceState:


### PR DESCRIPTION
Fixes #3

# Context

Add support for easily swapping focus between the test and non-test version of a file.

Usage:
1. From a non-test file, trigger the "go to or from" action.
2. This sends you to the test version of the file.
3. From the test file, trigger the find-or-create action.
4. This sends to to the original version of the file, or creates it if it doesn't exist.

**Note: this must be activated from the non-test file first.**
This is a limitation of the full regex path replacement support. Regex's are non-reversible, so you can't lookup a source file from a test file without a regex pattern that has been manually created, and possible not even then.

Once the feature is activated from the source -> test directly, the swapping will work correctly.